### PR TITLE
[-] BO : Fix VAT field hide/show in Address page

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -24,7 +24,6 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 include(dirname(__FILE__).'/../../config/config.inc.php');
-include(dirname(__FILE__).'/../../init.php');
 include(dirname(__FILE__).'/vatnumber.php');
 
 echo VatNumber::isApplicable(Tools::getValue('id_country'));


### PR DESCRIPTION
The ajax call to vatnumber module is used also to show or hide VAT field in address page in Back Office depends on selected country.
The init file inclusion in conjuction with modules that make redirects in front office make the call to fail so when you are in a customer address page the vat_number field is hidden and you can't modify or see the vat number.
