### PR TITLE
Avoid to use the webservice if not an european Country

### DIFF
--- a/vatnumber.php
+++ b/vatnumber.php
@@ -300,7 +300,7 @@ class VatNumber extends TaxManagerModule
 		$form = $params['form'];
 		$is_valid = true;
 
-		if (($vatNumber = $form->getField('vat_number')) && Configuration::get('VATNUMBER_MANAGEMENT') && Configuration::get('VATNUMBER_CHECKING')) {
+		if (($vatNumber = $form->getField('vat_number')) && Configuration::get('VATNUMBER_MANAGEMENT') && Configuration::get('VATNUMBER_CHECKING') && VatNumber::isApplicable(Tools::getValue('id_country'))) {
 			$isAVatNumber = VatNumber::WebServiceCheck($vatNumber->getValue());
 			if (is_array($isAVatNumber) && count($isAVatNumber) > 0) {
 				$vatNumber->addError($isAVatNumber[0]);


### PR DESCRIPTION
The web service, if active, was fired even for country VAT check outside the Europe, that will not validate for example other VAT code like the Chile: xx.xxx.xxx-x



| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Remove the Webservice Call for non European Country
| Type?         | FIX
| How to test?  | Before the fix use a Chile country and try to use a VAT number (correct for chile) the webservice will continue to not validate.


