### PR TITLE
Give more infos in case the VAT nr. is not registered in VIES database

### DIFF
--- a/vatnumber.php
+++ b/vatnumber.php
@@ -166,7 +166,7 @@ class VatNumber extends TaxManagerModule
 				{
 					@ini_restore('default_socket_timeout');
 
-					return array(Tools::displayError('VAT number not found'));
+					return array(Tools::displayError('VAT number not found, please verify the <a href="https://ec.europa.eu/taxation_customs/vies/?locale=en" target="_blank" rel="noopener">VIES registry</a>.'));
 				}
 				else if (preg_match('/valid VAT number/i', $page_res))
 				{


### PR DESCRIPTION
Could be nice to extend the message to give more info and a link to custoemr to verify in the VIES database why their VAT number are not accepted



| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Extend VAT not found message
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no

![image](https://user-images.githubusercontent.com/16102074/92143486-a4831780-ee15-11ea-88e6-29827dd109be.png)

