### PR TITLE
Advanced VIES check

### DIFF
--- a/vatnumber.php
+++ b/vatnumber.php
@@ -147,7 +147,7 @@ class VatNumber extends TaxManagerModule
 		if ((int) Configuration::get('VATNUMBER_COUNTRY') === (int) $id_country) {
 			return 0;
 		} else {
-			return (((int)$id_country && array_key_exists(Country::getIsoById($id_country), self::getPrefixIntracomVAT())) ? 1 : 0);
+			return (((int) $id_country && array_key_exists(Country::getIsoById($id_country), self::getPrefixIntracomVAT())) ? 1 : 0);
 		}
 	}
 

--- a/vatnumber.php
+++ b/vatnumber.php
@@ -144,8 +144,7 @@ class VatNumber extends TaxManagerModule
 
 	public static function isApplicable($id_country)
 	{
-		if( (int)Configuration::get('VATNUMBER_COUNTRY') == (int)$id_country) 
-		{
+		if ((int) Configuration::get('VATNUMBER_COUNTRY') === (int) $id_country) {
 			return 0;
 		} else {
 			return (((int)$id_country && array_key_exists(Country::getIsoById($id_country), self::getPrefixIntracomVAT())) ? 1 : 0);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | 1) Check only the VIES for European country 2) Check only the VIES if the country of customer is different from country of the seller.
| Type?         | bug fix / improvement 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #14 #15
| How to test?  | complete an order and use a customer address with same country of the store seller. Before the views was checked now is not need to be checked because is not an export is intra country selling and not need any VIES test. Only European countries are invlved in VIES so extra EU customer not need any VIEWS check


